### PR TITLE
Add close button to bank card modal

### DIFF
--- a/src/components/bank-card/bank-card.vue
+++ b/src/components/bank-card/bank-card.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="modal-overlay" v-if="visible" @click.self="close">
 		<div class="card-form">
+            <button class="modal-close" @click="close" aria-label="Close">&times;</button>
 			<div class="card-list">
 				<div class="card-item" :class="{ '-active' : isCardFlipped }">
 					<div class="card-item__side -front">
@@ -221,7 +222,7 @@ export default {
 	left:             0;
 	right:            0;
 	bottom:           0;
-	background-color: transparent;
+	background-color: rgba(0,0,0,0.5);
 	display:          flex;
 	align-items:      center;
 	justify-content:  center;
@@ -236,6 +237,15 @@ body {
 	background:  #ddeefc;
 	font-family: "Source Sans Pro", sans-serif;
 	font-size:   16px;
+}
+.modal-close {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: transparent;
+        border: none;
+        font-size: 24px;
+        cursor: pointer;
 }
 
 * {
@@ -260,6 +270,7 @@ body {
 	max-width: 570px;
 	margin:    auto;
 	width:     100%;
+        position: relative;
 
 	@media screen and (max-width: 576px) {
 		margin: 0 auto;

--- a/src/views/CoursesPage.vue
+++ b/src/views/CoursesPage.vue
@@ -329,7 +329,7 @@ export default {
 
 		<!-- Модальное окно с банковской картой -->
 
-		<bank-card :isOpen="isModalOpen.value"/>
+		<bank-card :visible="isModalOpen" @close="closeModal"/>
 
 		<!-- Блок содержание курса -->
 

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -133,13 +133,12 @@ document.addEventListener('DOMContentLoaded', () => {
 	<div class="wrapper">
 		<skils/>
 	</div>
-	<button @click="isOpen=!isOpen">
+        <button @click="isOpen=!isOpen">
 
-	</button>
-	<bank-card
-	:visible="isOpen">
-
-	</bank-card>
+        </button>
+        <bank-card
+        :visible="isOpen" @close="isOpen=false">
+        </bank-card>
 
 	<!-- БЛОК ФОРМЫ -->
 


### PR DESCRIPTION
## Summary
- add close button and overlay styling to `bank-card.vue`
- hook up modal closing in Course and Main pages

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm run test:unit` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684a82c386788332a65d1244509c0ca4